### PR TITLE
feat: add support for oauth1

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ Identity provider support
 * Facebook
 * Apple
 * OTP
+* Twitter
 
 Other modules and links out there
 ---------------------------------

--- a/df_auth/contants.py
+++ b/df_auth/contants.py
@@ -1,0 +1,23 @@
+from django.conf import settings
+from django.utils.module_loading import import_string
+from social_core.backends.oauth import BaseOAuth1
+from social_core.backends.oauth import BaseOAuth2
+
+
+AUTHENTICATION_BACKENDS = [
+    import_string(backend) for backend in settings.AUTHENTICATION_BACKENDS
+]
+
+OAUTH2_BACKENDS_CHOICES = []
+OAUTH1_BACKENDS_CHOICES = []
+
+# Add supported providers to corresponding constants.
+for backend in AUTHENTICATION_BACKENDS:
+    if not hasattr(backend, "name"):
+        continue
+
+    # Add backends to corresponding choices.
+    if isinstance(backend(), BaseOAuth1):
+        OAUTH1_BACKENDS_CHOICES.append((backend.name, backend.name))
+    elif isinstance(backend(), BaseOAuth2):
+        OAUTH2_BACKENDS_CHOICES.append((backend.name, backend.name))

--- a/df_auth/drf/urls.py
+++ b/df_auth/drf/urls.py
@@ -12,6 +12,7 @@ from .viewsets import ConnectViewSet
 from .viewsets import InviteViewSet
 from .viewsets import OTPViewSet
 from .viewsets import SignupViewSet
+from .viewsets import SocialOAuth1TokenViewSet
 from .viewsets import SocialTokenViewSet
 from .viewsets import TokenViewSet
 from .viewsets import UnlinkViewSet
@@ -27,5 +28,6 @@ router.register("change", ChangeViewSet, basename="change")
 router.register("signup", SignupViewSet, basename="signup")
 router.register("otp", OTPViewSet, basename="otp")
 router.register("social", SocialTokenViewSet, basename="social")
+router.register("social/oauth1", SocialOAuth1TokenViewSet, basename="social_oauth1")
 
 urlpatterns = router.urls

--- a/df_auth/drf/viewsets.py
+++ b/df_auth/drf/viewsets.py
@@ -4,6 +4,7 @@ from .serializers import ConnectSerializer
 from .serializers import InviteSerializer
 from .serializers import OTPObtainSerializer
 from .serializers import SignupSerializer
+from .serializers import SocialOAuth1TokenObtainSerializer
 from .serializers import SocialTokenObtainSerializer
 from .serializers import TokenObtainSerializer
 from .serializers import TokenSerializer
@@ -98,6 +99,21 @@ class SocialTokenViewSet(ValidationOnlyCreateViewSet):
         methods=["post"],
         detail=False,
         serializer_class=SocialTokenObtainSerializer,
+        permission_classes=(permissions.IsAuthenticated,),
+    )
+    def connect(self, request, *args, **kwargs):
+        return self.create(request, *args, **kwargs)
+
+
+class SocialOAuth1TokenViewSet(ValidationOnlyCreateViewSet):
+    serializer_class = SocialOAuth1TokenObtainSerializer
+    response_serializer_class = TokenSerializer
+    permission_classes = (IsUnauthenticated,)
+
+    @action(
+        methods=["post"],
+        detail=False,
+        serializer_class=SocialOAuth1TokenObtainSerializer,
         permission_classes=(permissions.IsAuthenticated,),
     )
     def connect(self, request, *args, **kwargs):

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -17,6 +17,7 @@ AUTHENTICATION_BACKENDS = [
     "social_core.backends.google.GoogleOAuth2",
     "social_core.backends.facebook.FacebookOAuth2",
     "social_core.backends.apple.AppleIdAuth",
+    "social_core.backends.twitter.TwitterOAuth",
 ]
 
 INSTALLED_APPS = [
@@ -112,3 +113,6 @@ EMAIL_PORT = os.environ.get("EMAIL_PORT", "")
 EMAIL_USE_SSL = os.environ.get("EMAIL_USE_SSL", "")
 EMAIL_HOST_USER = os.environ.get("EMAIL_HOST_USER", "")
 EMAIL_HOST_PASSWORD = os.environ.get("EMAIL_HOST_PASSWORD", "")
+
+SOCIAL_AUTH_TWITTER_KEY = os.environ.get("SOCIAL_AUTH_TWITTER_KEY", "")
+SOCIAL_AUTH_TWITTER_SECRET = os.environ.get("SOCIAL_AUTH_TWITTER_SECRET", "")

--- a/tests/test_app/tests.py
+++ b/tests/test_app/tests.py
@@ -1,12 +1,159 @@
+from df_auth.drf.serializers import SocialOAuth1TokenObtainSerializer
+from df_auth.drf.serializers import SocialTokenObtainSerializer
+from df_auth.drf.viewsets import SocialOAuth1TokenViewSet
+from df_auth.strategy import DRFStrategy
 from django.contrib.auth import get_user_model
+from django.urls import reverse
+from rest_framework.test import APIRequestFactory
+from rest_framework.test import APITestCase
+from rest_framework.test import force_authenticate
+from social_django.models import DjangoStorage
+from unittest.mock import MagicMock
+from unittest.mock import patch
 
-import pytest
+import json
 
 
 User = get_user_model()
 
-pytestmark = [pytest.mark.django_db]
+
+class SocialTokenObtainSerializerTests(APITestCase):
+    """Tests for the SocialTokenObtainSerializer serializer."""
+
+    def setUp(self):
+        """Set up the test case by creating necessary test data and objects."""
+        self.user = User.objects.create_user(
+            email="testuser@example.com", password="testpassword"
+        )
+        # Create request object
+        self.request = APIRequestFactory()
+        self.request.user = self.user
+        self.request.session = {}
+        self.request.social_strategy = DRFStrategy(DjangoStorage, self.request)
+        self.access_token = "test"
+
+        self.serializer = SocialTokenObtainSerializer
+
+    @patch("df_auth.drf.serializers.load_backend")
+    def test_valid_data_oauth2(self, load_backend_mock):
+        """Test that a valid social access token can be used to authenticate a user."""
+        provider = "facebook"
+
+        # Mock return values.
+        backend = MagicMock()
+        backend.name = provider
+        load_backend_mock.return_value = backend
+        mock_do_auth = backend.do_auth = MagicMock(return_value=self.user)
+
+        valid_data = {
+            "provider": "facebook",
+            "access_token": self.access_token,
+            "first_name": "John",
+            "last_name": "Doe",
+        }
+        serializer = self.serializer(data=valid_data, context={"request": self.request})
+        # Test to ensure no exception was raised.
+        serializer.is_valid(raise_exception=True)
+
+        # Ensure the mocked methods are called with the correspecting parameters.
+        mock_do_auth.assert_called_once_with(self.access_token, user=self.user)
+        load_backend_mock.assert_called_once_with(
+            self.request.social_strategy, provider, redirect_uri=None
+        )
+
+        # Ensure the `token` key exist in the validated response
+        self.assertIn("token", serializer.validated_data)
 
 
-def test_dummy():
-    assert 1 == 1
+class SocialOAuth1TokenObtainSerializerTests(APITestCase):
+    """Tests for the SocialTokenObtainSerializer serializer."""
+
+    def setUp(self):
+        """Set up the test case by creating necessary test data and objects."""
+        self.user = User.objects.create_user(
+            email="testuser@example.com", password="testpassword"
+        )
+        # Create request object
+        self.request = APIRequestFactory()
+        self.request.user = self.user
+        self.request.session = {}
+        self.request.social_strategy = DRFStrategy(DjangoStorage, self.request)
+
+        self.serializer = SocialOAuth1TokenObtainSerializer
+
+    @patch("df_auth.drf.serializers.load_backend")
+    def test_valid_data_oauth1(self, load_backend_mock):
+        """Test that a valid social oauth_token and oauth_token_secret can be used to authenticate a user."""
+        provider = "twitter"
+        oauth_token = "test"
+        oauth_token_secret = "test2"
+
+        # Mock return values.
+        backend = MagicMock()
+        backend.name = provider
+        load_backend_mock.return_value = backend
+        mock_do_auth = backend.do_auth = MagicMock(return_value=self.user)
+
+        valid_data = {
+            "provider": provider,
+            "oauth_token": oauth_token,
+            "oauth_token_secret": oauth_token_secret,
+        }
+        serializer = self.serializer(data=valid_data, context={"request": self.request})
+        # Test to ensure no exception was raised.
+        serializer.is_valid(raise_exception=True)
+
+        # Ensure the mocked methods are called with the correspecting parameters.
+        mock_do_auth.assert_called_once_with(
+            {"oauth_token": oauth_token, "oauth_token_secret": oauth_token_secret},
+            user=self.user,
+        )
+        load_backend_mock.assert_called_once_with(
+            self.request.social_strategy, provider, redirect_uri=None
+        )
+
+        # Ensure the `token` key exist in the validated response
+        self.assertIn("token", serializer.validated_data)
+
+
+class SocialOAuth1TokenViewSetTests(APITestCase):
+    def setUp(self):
+        self.basic_user_info = {
+            "email": "test@gmail.com",
+            "first_name": "John",
+            "last_name": "Doe",
+        }
+        self.factory = APIRequestFactory()
+        self.provider = "twitter"
+        self.user = User.objects.create(**self.basic_user_info)
+        self.data = {
+            "oauth_token": "test_token",
+            "oauth_token_secret": "test_token_secret",
+            "provider": self.provider,
+        }
+
+    def test_connect_authenticated(self):
+        """Test an aunthenticated user accessing the endpoint."""
+        request = self.factory.post(
+            reverse("social_oauth1-connect"), data=self.data, format="json"
+        )
+        force_authenticate(request, user=self.user)
+        response = SocialOAuth1TokenViewSet.as_view({"post": "connect"})(request)
+        self.assertEqual(response.status_code, 403)
+
+    @patch("df_auth.drf.serializers.load_backend")
+    def test_connect_unauthenticated(self, mock_load_backend):
+        """Test an unauthenticated user accessing the endpoint."""
+        # Mock return values.
+        backend = MagicMock(name=self.provider)
+        mock_load_backend.return_value = backend
+        backend.do_auth = MagicMock(return_value=self.user)
+
+        request = self.factory.post(
+            reverse("social_oauth1-connect"), data=self.data, format="json"
+        )
+        request.session = {}
+        response = SocialOAuth1TokenViewSet.as_view({"post": "connect"})(request)
+        self.assertEqual(response.status_code, 200)
+        response.render()
+        self.assertIn("token", json.loads(response.content))


### PR DESCRIPTION
Updated SocialTokenObtainSerializer to support OAuth1 and OAuth2 authentication types

- Updated the SocialTokenObtainSerializer to handle both OAuth1 and OAuth2 authentication types, allowing for the exchange of social authentication tokens for Django REST Framework tokens.
- Improved validation of input data to ensure that required fields are provided and that the selected provider and authentication type are valid choices.
- Refactored the serializer to use constants defined in a separate `constants.py` file for the valid provider choices, promoting code organization and reusability.


## Response from endpoint using a live test twitter tokens
![Screenshot 2023-05-30 at 21-10-39 Twitter _ Authorize an application](https://github.com/djangoflow/django-df-auth/assets/60811620/fdd12ee2-d80d-4f42-be9f-f1881ac0d2f6)

![Screenshot 2023-05-30 at 21-16-07 Social O Auth1 Token List – Django REST framework](https://github.com/djangoflow/django-df-auth/assets/60811620/abfba202-5757-459a-b4f8-5d284f8dca07)



closes #18 
